### PR TITLE
Fix Newtonsoft JSON import for iOS builds

### DIFF
--- a/Assets/Snapyr/Utils/JsonDotNet/Assemblies/Standalone/Newtonsoft.Json.dll.meta
+++ b/Assets/Snapyr/Utils/JsonDotNet/Assemblies/Standalone/Newtonsoft.Json.dll.meta
@@ -23,6 +23,7 @@ PluginImporter:
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
+        Exclude iOS: 0
   - first:
       Android: Android
     second:
@@ -47,7 +48,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
@@ -72,6 +73,15 @@ PluginImporter:
       enabled: 0
       settings:
         CPU: AnyCPU
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Configure "standalone" version to be included for iOS platform
builds

## Asana link:
https://app.asana.com/0/1200598365630412/1201029346793426 